### PR TITLE
fix: padding in storybook preview

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,7 +15,7 @@ const preview: Preview = {
   decorators: [
     (Story) => {
       return (
-        <Theme>
+        <Theme style={{ minHeight: "inherit" }}>
           <Story />
         </Theme>
       );


### PR DESCRIPTION
## What does this PR do?

- Storybook上でコンポーネントを表示すると謎の余白が発生する問題を修正