### PR TITLE
fix: add i18n config in storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,8 +1,25 @@
 import type { Preview } from "@storybook/react";
-import React from "react";
+import React, { useEffect } from "react";
 import "@radix-ui/themes/styles.css";
 import "../app/styles/font.css";
 import { Theme } from "@radix-ui/themes";
+import { I18nextProvider, useTranslation } from "react-i18next";
+import i18nConfig from "../i18n/config";
+
+export const globalTypes = {
+  locale: {
+    name: "Locale",
+    description: "Internationalization locale",
+    toolbar: {
+      icon: "globe",
+      items: [
+        { value: "en_US", title: "English" },
+        { value: "ja_JP", title: "日本語" }
+      ],
+      showName: true
+    }
+  }
+};
 
 const preview: Preview = {
   parameters: {
@@ -14,11 +31,20 @@ const preview: Preview = {
     }
   },
   decorators: [
-    (Story) => {
+    (Story, context) => {
+      const { locale } = context.globals;
+      const { i18n } = useTranslation();
+
+      useEffect(() => {
+        i18n.changeLanguage(locale);
+      }, [locale]);
+
       return (
-        <Theme>
-          <Story />
-        </Theme>
+        <I18nextProvider i18n={i18nConfig.default}>
+          <Theme>
+            <Story />
+          </Theme>
+        </I18nextProvider>
       );
     }
   ]


### PR DESCRIPTION
## What does this PR do?

- Storybook内でLocaleを変更できるように
- i18nの設定が適用されていなかったため，設定を適用